### PR TITLE
Setup cron job to be registered in elastic beanstalk

### DIFF
--- a/.ebextensions/cron-leaderonly-linux.config
+++ b/.ebextensions/cron-leaderonly-linux.config
@@ -16,7 +16,7 @@ packages:
     jq: []
 
 files:
-  "/usr/local/bin/test_cron.sh":
+  "/usr/local/bin/check_leader.sh":
     mode: "000755"
     owner: root
     group: root
@@ -43,7 +43,7 @@ files:
     group: root
     content: |
       #!/bin/bash
-      /usr/local/bin/test_cron.sh || exit
+      /usr/local/bin/check_leader.sh || exit
       # Now run commands that should run on only 1 instance.
       CONTAINER=`sudo docker ps | awk '$1!="CONTAINER" {print $1}'`
       sudo docker exec $CONTAINER /usr/local/bin/node /app/build/src/batch/coursebook

--- a/.ebextensions/cron-leaderonly-linux.config
+++ b/.ebextensions/cron-leaderonly-linux.config
@@ -11,62 +11,9 @@
 #### License for the specific language governing permissions and limitations under the License.
 ###################################################################################################
 
-###################################################################################################
-#### This configuration file allows a cron job to run only on one Linux instance in the environment.
-#### 
-#### The script "/usr/local/bin/test_cron.sh" will sort and compare the current instances in the
-#### Auto Scaling group and if it matches the first instance in the sorted list it will exit 0.
-#### This will mean that this script will only exit 0 for one of the instances in your environment.
-####
-#### The second script is an example of how you might use the "/usr/local/bin/test_cron.sh" script
-#### to execute commands and log a timestamp to "/tmp/cron_example.log".
-####
-#### A cron example is setup at "/etc/cron.d/cron_example" to execute the script 
-#### "/usr/local/bin/cron_example.sh" every minute. A command is also run upon each deployment to 
-#### clear any previous versions of "/etc/cron.d/cron_example" by removing 
-#### "/etc/cron.d/cron_example.bak".
-####
-#### Note that for the first script to gather the required information, additional IAM permissions
-#### will be needed to be added to a policy attached to the instance profile used by the instances
-#### in the environment. The policy shown below will grant the access needed. Note that the default
-#### instance profile for Elastic Beanstalk is "aws-elasticbeanstalk-ec2-role".
-####
-#### How to create a New Policy
-####         - https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html
-####
-#### Adding Permissions to the Default Instance Profile
-####         - https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html#iam-instanceprofile-addperms
-####
-#### NB: Please note that as the "/usr/local/bin/test_cron.sh" script makes use of the EC2 health
-#### status to determine "InService" instances in the Auto Scaling Group, the cron could fail to
-#### run if the "leader" instance has failed and Auto Scaling has not yet changed the EC2 instance
-#### state.
-###################################################################################################
-####
-#### {
-####   "Version": "2012-10-17",
-####   "Statement": [
-####     {
-####       "Sid": "Stmt1409855610000",
-####       "Effect": "Allow",
-####       "Action": [ "autoscaling:DescribeAutoScalingGroups" ],
-####       "Resource": [ "*" ]
-####     },
-####     {
-####       "Sid": "Stmt1409855649000",
-####       "Effect": "Allow",
-####       "Action": [ "ec2:DescribeTags" ],
-####       "Resource": [ "*" ]
-####     }
-####   ]
-#### }
-####
-###################################################################################################
-###################################################################################################
-
-packages: 
+packages:
   yum:
-    jq: [] 
+    jq: []
 
 files:
   "/usr/local/bin/test_cron.sh":
@@ -90,7 +37,7 @@ files:
       # If the instance ids are the same exit 0
       [ "$FIRST" = "$INSTANCE_ID" ]
 
-  "/usr/local/bin/cron_example.sh":
+  "/usr/local/bin/cron_coursebook.sh":
     mode: "000755"
     owner: root
     group: root
@@ -107,8 +54,8 @@ files:
     owner: root
     group: root
     content: |
-      40 10 * * * root /usr/local/bin/cron_example.sh
-      0 21 * * * root /usr/local/bin/cron_example.sh
+      40 10 * * * root /usr/local/bin/cron_coursebook.sh
+      0 21 * * * root /usr/local/bin/cron_coursebook.sh
 
 commands:
   rm_old_cron:

--- a/.ebextensions/cron-leaderonly-linux.config
+++ b/.ebextensions/cron-leaderonly-linux.config
@@ -1,0 +1,116 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file allows a cron job to run only on one Linux instance in the environment.
+#### 
+#### The script "/usr/local/bin/test_cron.sh" will sort and compare the current instances in the
+#### Auto Scaling group and if it matches the first instance in the sorted list it will exit 0.
+#### This will mean that this script will only exit 0 for one of the instances in your environment.
+####
+#### The second script is an example of how you might use the "/usr/local/bin/test_cron.sh" script
+#### to execute commands and log a timestamp to "/tmp/cron_example.log".
+####
+#### A cron example is setup at "/etc/cron.d/cron_example" to execute the script 
+#### "/usr/local/bin/cron_example.sh" every minute. A command is also run upon each deployment to 
+#### clear any previous versions of "/etc/cron.d/cron_example" by removing 
+#### "/etc/cron.d/cron_example.bak".
+####
+#### Note that for the first script to gather the required information, additional IAM permissions
+#### will be needed to be added to a policy attached to the instance profile used by the instances
+#### in the environment. The policy shown below will grant the access needed. Note that the default
+#### instance profile for Elastic Beanstalk is "aws-elasticbeanstalk-ec2-role".
+####
+#### How to create a New Policy
+####         - https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html
+####
+#### Adding Permissions to the Default Instance Profile
+####         - https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html#iam-instanceprofile-addperms
+####
+#### NB: Please note that as the "/usr/local/bin/test_cron.sh" script makes use of the EC2 health
+#### status to determine "InService" instances in the Auto Scaling Group, the cron could fail to
+#### run if the "leader" instance has failed and Auto Scaling has not yet changed the EC2 instance
+#### state.
+###################################################################################################
+####
+#### {
+####   "Version": "2012-10-17",
+####   "Statement": [
+####     {
+####       "Sid": "Stmt1409855610000",
+####       "Effect": "Allow",
+####       "Action": [ "autoscaling:DescribeAutoScalingGroups" ],
+####       "Resource": [ "*" ]
+####     },
+####     {
+####       "Sid": "Stmt1409855649000",
+####       "Effect": "Allow",
+####       "Action": [ "ec2:DescribeTags" ],
+####       "Resource": [ "*" ]
+####     }
+####   ]
+#### }
+####
+###################################################################################################
+###################################################################################################
+
+packages: 
+  yum:
+    jq: [] 
+
+files:
+  "/usr/local/bin/test_cron.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      INSTANCE_ID=`curl http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null`
+      REGION=`curl -s http://169.254.169.254/latest/dynamic/instance-identity/document 2>/dev/null | jq -r .region`
+
+      # Find the Auto Scaling Group name from the Elastic Beanstalk environment
+      ASG=`aws ec2 describe-tags --filters "Name=resource-id,Values=$INSTANCE_ID" \
+          --region $REGION --output json | jq -r '.[][] | select(.Key=="aws:autoscaling:groupName") | .Value'`
+
+      # Find the first instance in the Auto Scaling Group
+      FIRST=`aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names $ASG \
+          --region $REGION --output json | \
+          jq -r '.AutoScalingGroups[].Instances[] | select(.LifecycleState=="InService") | .InstanceId' | sort | head -1`
+
+      # If the instance ids are the same exit 0
+      [ "$FIRST" = "$INSTANCE_ID" ]
+
+  "/usr/local/bin/cron_example.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      /usr/local/bin/test_cron.sh || exit
+      # Now run commands that should run on only 1 instance.
+      CONTAINER=`sudo docker ps | awk '$1!="CONTAINER" {print $1}'`
+      sudo docker exec $CONTAINER /usr/local/bin/node /app/build/src/batch/coursebook
+
+
+  "/etc/cron.d/cron_coursebook":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      40 10 * * * root /usr/local/bin/cron_example.sh
+      0 21 * * * root /usr/local/bin/cron_example.sh
+
+commands:
+  rm_old_cron:
+    command: "rm -fr /etc/cron.d/cron_coursebook.bak"
+    ignoreErrors: true

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Upload Dockerrun.aws.json to S3
       run: |
         mv Dockerrun-dev.aws.json Dockerrun.aws.json
-        zip deploy-dev.zip Dockerrun.aws.json
+        zip -r deploy-dev.zip Dockerrun.aws.json .ebextensions
         aws s3 cp deploy-dev.zip s3://$S3_BUCKET_NAME/deploy-dev.zip
 
     - name: Login to ECR

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Upload Dockerrun.aws.json to S3
       run: |
-        zip deploy.zip Dockerrun.aws.json
+        zip -r deploy.zip Dockerrun.aws.json .ebextensions
         aws s3 cp deploy.zip s3://$S3_BUCKET_NAME/deploy.zip
 
     - name: Login to ECR


### PR DESCRIPTION
## 변경 사항
elastic beanstalk의 cron job 이 자동으로 등록되도록 설정 ( lambda는 보류 )
만약 여러 ec2 instance가 존재할 경우 하나의 instance ( leader )에서만 cron job 실행

등록한 cron job은 docker container를 찾고 해당 container에 node coursebook 명령어 실행하는 job