### PR TITLE
Use UserInfoAsSnakeCase for ev-service

### DIFF
--- a/src/api/middleware/Server2ServerMiddleware.ts
+++ b/src/api/middleware/Server2ServerMiddleware.ts
@@ -12,7 +12,7 @@ export async function replaceAllUserId2UserInfo(body) {
                     if (key === 'user_id') {
                         return new Promise(
                             async (resolve, reject) => {
-                                o['user'] = UserService.getUserInfo(await UserService.getByMongooseId(o[key]))
+                                o['user'] = UserService.getUserInfoAsSnakeCase(await UserService.getByMongooseId(o[key]))
                                 delete o[key]
                                 resolve('next')
                             }

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -5,6 +5,7 @@ import CourseBookService = require('@app/core/coursebook/CourseBookService');
 
 import User from '@app/core/user/model/User';
 import UserInfo from '@app/core/user/model/UserInfo';
+import UserInfoAsSnakeCase from '@app/core/user/model/UserInfoAsSnakeCase';
 
 export function getByMongooseId(mongooseId: string): Promise<User> {
   return UserRepository.findActiveByMongooseId(mongooseId);
@@ -40,6 +41,17 @@ export function getUserInfo(user: User): UserInfo {
     isAdmin: user.isAdmin,
     regDate: user.regDate,
     notificationCheckedAt: user.notificationCheckedAt,
+    email: user.email,
+    local_id: user.credential.localId,
+    fb_name: user.credential.fbName
+  }
+}
+
+export function getUserInfoAsSnakeCase(user: User): UserInfoAsSnakeCase {
+  return {
+    is_admin: user.isAdmin,
+    reg_date: user.regDate,
+    notification_checked_at: user.notificationCheckedAt,
     email: user.email,
     local_id: user.credential.localId,
     fb_name: user.credential.fbName

--- a/src/core/user/model/UserInfoAsSnakeCase.ts
+++ b/src/core/user/model/UserInfoAsSnakeCase.ts
@@ -1,0 +1,8 @@
+export default interface UserInfoAsSnakeCase {
+  is_admin: boolean;
+  reg_date: Date;
+  notification_checked_at: Date;
+  email: string;
+  local_id: string;
+  fb_name: string;
+};


### PR DESCRIPTION
# Major Changes
## 1. Use UserInfoAsSnakeCase for ev-service
- 강의평 서비스에 대해서 "user"를 padding 해줄 때, 일관되게 snake_case 가 사용되도록 함
