### PR TITLE
Handling ev-service error body and empty body

### DIFF
--- a/src/api/routes/EvaluationRouter.ts
+++ b/src/api/routes/EvaluationRouter.ts
@@ -1,5 +1,4 @@
 import ExpressPromiseRouter from "express-promise-router";
-import ApiError from "@app/api/error/ApiError";
 import {replaceAllUserId2UserInfo} from "@app/api/middleware/Server2ServerMiddleware";
 import * as request from "request-promise-native";
 import * as property from '@app/core/config/property';
@@ -22,10 +21,12 @@ router.all('/*', async function (req, res, next) {
             body: req.body,
             json: true
         }).then(async function (body) {
-            await replaceAllUserId2UserInfo(body)
+            if (body !== undefined) {
+                await replaceAllUserId2UserInfo(body)
+            }
             return res.json(body);
         }).catch(function (err) {
-            throw new ApiError(err.response.statusCode, err.response.errorCode, err.response.statusMessage)
+            return res.status(err.response.statusCode).json(err.response.body);
         });
     } catch (err) {
         next(err)


### PR DESCRIPTION
related PRs: #163 

# Major Changes
## 1. ev-service 에서 body가 없는 경우 snutt 서버에서 500 발생하지 않도록 대응

## 2. ev-service 의 error 시 내려주는 response body 가 snutt 서버를 거칠 때도 그대로 전달되도록 대응
```
{
    "error": {
        "code": 29001,
        "message": "EVALUATION_ALREADY_EXISTS"
    }
}
```