### PR TITLE
Timetable 정렬 방식 변경

### DIFF
--- a/src/core/timetable/TimetableRepository.ts
+++ b/src/core/timetable/TimetableRepository.ts
@@ -98,6 +98,29 @@ export async function findBySemester(year: number, semester: number): Promise<Ti
   return docs.map(fromMongoose);
 }
 
+function sortByTitle(array: AbstractTimetable[]): AbstractTimetable[] {
+  const regexp = / (\([0-9]+\))/;
+  const srcs = array.filter(item => (!regexp.test(item.title)));
+  const result = [];
+
+  for (let i = 0; i < srcs.length; i++) {
+    const clusters = [srcs[i], ...array.filter(item => isDuplicated(srcs[i].title, item.title))];
+    clusters.sort((former, latter) => sortTitle(former.title, latter.title));
+    result.push(...clusters);
+  }
+
+  return result;
+}
+
+function sortTitle(former: string, latter: string) {
+  if (latter > former) return -1;
+  else return 1;
+}
+
+function isDuplicated(srcTitle: string, dupTitle: string): Boolean {
+  return (dupTitle != srcTitle) && (srcTitle.split(' ')[0] == dupTitle.split(' ')[0]);
+}
+
 export async function findAbstractListByUserId(userId: string): Promise<AbstractTimetable[]> {
   const docs = await mongooseModel.aggregate([{
     $match: {'user_id': userId}
@@ -124,9 +147,10 @@ export async function findAbstractListByUserId(userId: string): Promise<Abstract
         }
       }
     },
-      {$sort: {title:1}}
+      {$sort: {_id:1}}
   ]).exec()
-  return docs
+  const sortedDocs = sortByTitle(docs);
+  return sortedDocs;
 }
 
 export async function findHavingLecture(year: number, semester: number, courseNumber: string, lectureNumber: string): Promise<Timetable[]> {

--- a/src/core/timetable/TimetableRepository.ts
+++ b/src/core/timetable/TimetableRepository.ts
@@ -124,7 +124,7 @@ export async function findAbstractListByUserId(userId: string): Promise<Abstract
         }
       }
     },
-      {$sort: {_id:1}}
+      {$sort: {title:1}}
   ]).exec()
   return docs
 }


### PR DESCRIPTION
### Major Changes
1. findAbstractListByUserId 에서 sorting이 다음과 같은 조건을 만족하도록 변경
- 기존 테이블의 순서는 그대로 유지된다.
- 복사한 테이블은 복사된 테이블 바로 밑에 온다.

원래 `Timetable` 모델에 순서를 기록하는 필드를 추가해서 정렬하는 방식이 더 좋다고 생각했는데 **기존에 존재하는 데이터들에는 영향을 주지 못할 것 같아(맞나요?)** 따로 sorting 함수를 추가했습니다.