### PR TITLE
Update to do not check latestSemester

### DIFF
--- a/src/batch/coursebook/sugangsnu/SugangSnu2Service.ts
+++ b/src/batch/coursebook/sugangsnu/SugangSnu2Service.ts
@@ -81,8 +81,10 @@ async function isCoursebookOpened(year: number, semester: number): Promise<boole
             }
 
             return Promise.resolve(
-              (year < latestYear) ||
-              (year == latestYear && semester <= latestSemester)
+              true
+              // 수강편람 이후에도 latestSemseter가 업데이트 되지 않는 경우가 있어 항상 엑셀을 fetch하도록 변경
+              // (year < latestYear) ||
+              // (year == latestYear && semester <= latestSemester)
             );
         });
     }, {


### PR DESCRIPTION
### 변경사항
- 수강편람이 있어도 latestSemester 가 sugangSnu에서 업데이트 안됨
- latestSemester와 비교하는 로직이 있었는데 삭제
- 항상 excel 확인해서 강의 긁어옴 ( 아무 강의 없을 때 이전과 동일한 것 확인 )
