### PR TITLE
마이너 업데이트

### DIFF
--- a/src/core/timetable/TimetableLectureService.ts
+++ b/src/core/timetable/TimetableLectureService.ts
@@ -198,7 +198,7 @@ function getAvailableColorIndices(table: Timetable): number[] {
 
   var ret:number[] = [];
   // colorIndex = 0 is custom color!
-  for (var i=1; i<LectureColorService.MAX_NUM_COLOR; i++) {
+  for (var i=1; i<=LectureColorService.MAX_NUM_COLOR; i++) {
     if (!checked[i]) ret.push(i);
   }
   return ret;

--- a/src/core/timetable/util/TimePlaceUtil.ts
+++ b/src/core/timetable/util/TimePlaceUtil.ts
@@ -103,7 +103,7 @@ export function timeJsonToMask(timeJson:Array<TimePlace>, duplicateCheck?:boolea
 
     timeJson.forEach(function(lecture, lectureIdx) {
         var dayIdx = Number(lecture.day);
-        var end = Number(lecture.start) + Number(lecture.len);
+        var end = Number(lecture.start) + Math.ceil(Number(lecture.len) * 2) / 2;
         if (Number(lecture.len) <= 0) throw new InvalidLectureTimeJsonError();
         if (lecture.start < 0) logger.warn("timeJsonToMask: lecture start less than 0");
         if (lecture.start > 14) logger.warn("timeJsonToMask: lecture start bigger than 14");


### PR DESCRIPTION
### 변경사항(2건)
- 랜덤 색상 설정에서 자수정 설정 안되는 버그 해결
  - 현상황: 색상이 안겹치도록 랜덤하게 부여되는데 8개까지밖에 안됨 (9번째 색 자동으론 절대 설정안됨)
  - <img width="288" alt="스크린샷 2022-09-07 오후 6 22 07" src="https://user-images.githubusercontent.com/48513130/188842278-f11823c7-91b0-41e8-a799-184eb25c6acb.png">
- 강의시간(len)이 1.2와 같이 들어와도 time_mask에서 한칸(30분) 차지하도록 변경
  - ex) timeJsonToMask에서 len
    - 1.0 -> 1.0
    - 1.1 -> 1.5
    - 1.2 -> 1.5 
    - 1.7 -> 2