### PR TITLE
Handle when query param exists in my lectures latest api for ev service

### DIFF
--- a/src/api/routes/EvaluationRouter.ts
+++ b/src/api/routes/EvaluationRouter.ts
@@ -24,7 +24,7 @@ restGet(router, '/v1/users/me/lectures/latest')(async function (context, req) {
     const snuttLectureInfo: string = JSON.stringify(await TimetableService.getLecturesTakenByUserInLastSemesters(user._id))
 
     req.query.snutt_lecture_info = encodeURI(snuttLectureInfo)
-    let requestUri = snuttevDefaultRoutingUrl + req.url
+    let requestUri = snuttevDefaultRoutingUrl + req.path
     requestUri += '?' + Object.keys(req.query).map(key => key + '=' + req.query[key]).join('&')
 
     return request({

--- a/src/api/routes/EvaluationRouter.ts
+++ b/src/api/routes/EvaluationRouter.ts
@@ -21,11 +21,15 @@ restGet(router, '/v1/users/me/lectures/latest')(async function (context, req) {
     const evaluationServerHeader = {
         'Snutt-User-Id': user._id
     }
-    let snuttLectureInfo: string = JSON.stringify(await TimetableService.getLecturesTakenByUserInLastSemesters(user._id))
+    const snuttLectureInfo: string = JSON.stringify(await TimetableService.getLecturesTakenByUserInLastSemesters(user._id))
+
+    req.query.snutt_lecture_info = encodeURI(snuttLectureInfo)
+    let requestUri = snuttevDefaultRoutingUrl + req.url
+    requestUri += '?' + Object.keys(req.query).map(key => key + '=' + req.query[key]).join('&')
 
     return request({
         method: req.method,
-        uri: `${snuttevDefaultRoutingUrl}${req.path}?snutt_lecture_info=${encodeURI(snuttLectureInfo)}`,
+        uri: requestUri,
         headers: evaluationServerHeader,
         body: req.body,
         json: true


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C0PAVPS5T/p1667061084690459?thread_ts=1664801067.566279&cid=C0PAVPS5T

클라이언트가 보내는 query param 을 무시하는 버그 수정
