### PR TITLE
Modify /login_apple Logic for Transferring Apple Account 

### DIFF
--- a/src/api/routes/AuthRouter.ts
+++ b/src/api/routes/AuthRouter.ts
@@ -72,7 +72,7 @@ restPost(router, '/login_apple')(async function (context, req) {
     const user = await UserService.getByApple(userInfo.email);
 
     if (user) {
-      if (userInfo.transfer_sub != undefined) {
+      if (userInfo.transfer_sub != undefined && user.credential.appleSub !== user.credential.appleTransferSub) {
         logger.info("Apple transfer try: " + userInfo.transfer_sub);
 
         if (userInfo.transfer_sub === user.credential.appleTransferSub) {

--- a/src/api/routes/AuthRouter.ts
+++ b/src/api/routes/AuthRouter.ts
@@ -65,12 +65,25 @@ restPost(router, '/register_local')(async function (context, req) {
 
 restPost(router, '/login_apple')(async function (context, req) {
   if (!req.body.apple_token)
-    throw new ApiError(400, ErrorCode.NO_APPLE_ID_OR_TOKEN, 'apple_token required')
+    throw new ApiError(400, ErrorCode.NO_APPLE_ID_OR_TOKEN, 'apple_token required');
 
   try {
-    const userInfo = await AppleService.verifyAndDecodeAppleToken(req.body.apple_token)
-    const user = await UserService.getByApple(userInfo.email)
+    const userInfo = await AppleService.verifyAndDecodeAppleToken(req.body.apple_token);
+    const user = await UserService.getByApple(userInfo.email);
+
     if (user) {
+      if (userInfo.transfer_sub != undefined) {
+        logger.info("Apple transfer try: " + userInfo.transfer_sub);
+
+        if (userInfo.transfer_sub === user.credential.appleTransferSub) {
+          UserCredentialService.transferAppleCredential(user, userInfo.transfer_sub);
+          logger.info("Apple transfer success: " + userInfo.transfer_sub);
+        } else {
+          logger.error("Apple transfer failed: " + userInfo.transfer_sub + " !== " + user.credential.appleTransferSub);
+          throw new ApiError(403, ErrorCode.WRONG_APPLE_TOKEN, "Apple transfer failed");
+        }
+      }
+
       return {token: user.credentialHash, user_id: user._id}
     } else {
       const credential: UserCredential = await UserCredentialService.makeAppleCredential(userInfo.email, userInfo.sub);

--- a/src/api/routes/AuthRouter.ts
+++ b/src/api/routes/AuthRouter.ts
@@ -69,36 +69,42 @@ restPost(router, '/login_apple')(async function (context, req) {
 
   try {
     const userInfo = await AppleService.verifyAndDecodeAppleToken(req.body.apple_token, context.appType);
-    const user = await UserService.getByApple(userInfo.email);
 
-    if (user) {
-      if (userInfo.transfer_sub != undefined && user.credential.appleSub !== user.credential.appleTransferSub) {
-        logger.info("Apple transfer try: " + userInfo.transfer_sub);
+    let credential: UserCredential;
+    if (userInfo.transfer_sub != undefined) {
+      logger.info("Apple transfer sub exists: " + userInfo.transfer_sub);
+      const user = await UserService.getByAppleTransferSub(userInfo.transfer_sub);
 
-        if (userInfo.transfer_sub === user.credential.appleTransferSub) {
-          UserCredentialService.transferAppleCredential(user, userInfo.transfer_sub);
-          logger.info("Apple transfer success: " + userInfo.transfer_sub);
-        } else {
-          logger.error("Apple transfer failed: " + userInfo.transfer_sub + " !== " + user.credential.appleTransferSub);
-          throw new ApiError(403, ErrorCode.WRONG_APPLE_TOKEN, "Apple transfer failed");
-        }
+      if (user) {
+        UserCredentialService.transferAppleCredential(user, userInfo.sub, userInfo.email);
+        logger.info("Apple transfer success: " + userInfo.transfer_sub);
+        return {token: user.credentialHash, user_id: user._id};
+      } else {
+        credential = await UserCredentialService.makeAppleCredential(userInfo.email, userInfo.sub, userInfo.transfer_sub);
+        logger.info("Made apple credential with transfer sub: " + JSON.stringify(credential));
       }
-
-      return {token: user.credentialHash, user_id: user._id}
     } else {
-      const credential: UserCredential = await UserCredentialService.makeAppleCredential(userInfo.email, userInfo.sub);
-      logger.info("Made apple credential: " + JSON.stringify(credential));
-      const credentialHash: string = await UserCredentialService.makeCredentialHmac(credential);
-      const newUser: User = {
-        credential: credential,
-        credentialHash: credentialHash,
-        email: userInfo.email
+      logger.info("Apple transfer sub doesn't exist");
+      const user = await UserService.getByAppleEmail(userInfo.email);
+
+      if (user) {
+        return {token: user.credentialHash, user_id: user._id};
+      } else {
+        credential = await UserCredentialService.makeAppleCredential(userInfo.email, userInfo.sub);
+        logger.info("Made apple credential: " + JSON.stringify(credential));
       }
-      logger.info("New user info: " + JSON.stringify(newUser));
-      const inserted: User = await UserService.add(newUser);
-      logger.info("Inserted new user: " + JSON.stringify(inserted));
-      return {token: inserted.credentialHash, user_id: inserted._id};
     }
+      
+    const credentialHash: string = UserCredentialService.makeCredentialHmac(credential);
+    const newUser: User = {
+      credential: credential,
+      credentialHash: credentialHash,
+      email: userInfo.email
+    }
+    logger.info("New user info: " + JSON.stringify(newUser));
+    const inserted: User = await UserService.add(newUser);
+    logger.info("Inserted new user: " + JSON.stringify(inserted));
+    return {token: inserted.credentialHash, user_id: inserted._id};
   } catch (err) {
     if (err instanceof InvalidAppleTokenError) {
       throw new ApiError(403, ErrorCode.WRONG_APPLE_TOKEN, "wrong apple token");

--- a/src/api/routes/AuthRouter.ts
+++ b/src/api/routes/AuthRouter.ts
@@ -88,7 +88,7 @@ restPost(router, '/login_apple')(async function (context, req) {
       }
     } else {
       logger.info("Apple transfer sub doesn't exist");
-      const user = await UserService.getByAppleEmail(userInfo.email);
+      const user = await UserService.getByAppleSub(userInfo.sub);
 
       if (user) {
         return {token: user.credentialHash, user_id: user._id};

--- a/src/api/routes/AuthRouter.ts
+++ b/src/api/routes/AuthRouter.ts
@@ -77,8 +77,9 @@ restPost(router, '/login_apple')(async function (context, req) {
 
       if (user) {
         if (user.credential.appleSub !== userInfo.sub) {
+          logger.info("Apple transfer try: " + user.credential);
           UserCredentialService.transferAppleCredential(user, userInfo.sub, userInfo.email);
-          logger.info("Apple transfer success: " + userInfo.transfer_sub);
+          logger.info("Apple transfer success: " + user.credential);
         }
         return {token: user.credentialHash, user_id: user._id};
       } else {

--- a/src/api/routes/AuthRouter.ts
+++ b/src/api/routes/AuthRouter.ts
@@ -77,9 +77,9 @@ restPost(router, '/login_apple')(async function (context, req) {
 
       if (user) {
         if (user.credential.appleSub !== userInfo.sub) {
-          logger.info("Apple transfer try: " + user.credential);
+          logger.info("Apple transfer try: " + JSON.stringify(user.credential));
           UserCredentialService.transferAppleCredential(user, userInfo.sub, userInfo.email);
-          logger.info("Apple transfer success: " + user.credential);
+          logger.info("Apple transfer success: " + JSON.stringify(user.credential));
         }
         return {token: user.credentialHash, user_id: user._id};
       } else {

--- a/src/api/routes/AuthRouter.ts
+++ b/src/api/routes/AuthRouter.ts
@@ -76,8 +76,10 @@ restPost(router, '/login_apple')(async function (context, req) {
       const user = await UserService.getByAppleTransferSub(userInfo.transfer_sub);
 
       if (user) {
-        UserCredentialService.transferAppleCredential(user, userInfo.sub, userInfo.email);
-        logger.info("Apple transfer success: " + userInfo.transfer_sub);
+        if (user.credential.appleSub !== userInfo.sub) {
+          UserCredentialService.transferAppleCredential(user, userInfo.sub, userInfo.email);
+          logger.info("Apple transfer success: " + userInfo.transfer_sub);
+        }
         return {token: user.credentialHash, user_id: user._id};
       } else {
         credential = await UserCredentialService.makeAppleCredential(userInfo.email, userInfo.sub, userInfo.transfer_sub);

--- a/src/core/user/UserCredentialService.ts
+++ b/src/core/user/UserCredentialService.ts
@@ -13,7 +13,7 @@ import AlreadyRegisteredFbIdError from '@app/core/user/error/AlreadyRegisteredFb
 import InvalidFbIdOrTokenError from '@app/core/facebook/error/InvalidFbIdOrTokenError';
 import NotLocalAccountError from './error/NotLocalAccountError';
 import winston = require('winston');
-import AlreadyRegisteredAppleEmailError from "@app/core/user/error/AlreadyRegisteredAppleEmailError";
+import AlreadyRegisteredAppleSubError from "@app/core/user/error/AlreadyRegisteredAppleSubError";
 var logger = winston.loggers.get('default');
 
 let secretKey = property.get('core.secretKey');
@@ -133,12 +133,12 @@ export async function makeLocalCredential(id: string, password: string): Promise
 }
 
 export async function makeAppleCredential(appleEmail: string, appleSub: string, appleTransferSub?: string): Promise<UserCredential> {
-    if (await UserService.getByAppleEmail(appleEmail)) {
-        throw new AlreadyRegisteredAppleEmailError(appleEmail);
+    if (await UserService.getByAppleSub(appleSub)) {
+        throw new AlreadyRegisteredAppleSubError(appleSub);
     }
     return {
-        appleEmail: appleEmail,
         appleSub: appleSub,
+        appleEmail: appleEmail,
         appleTransferSub: appleTransferSub
     }
 }

--- a/src/core/user/UserCredentialService.ts
+++ b/src/core/user/UserCredentialService.ts
@@ -132,18 +132,20 @@ export async function makeLocalCredential(id: string, password: string): Promise
     }
 }
 
-export async function makeAppleCredential(appleEmail: string, appleSub: string): Promise<UserCredential> {
-    if (await UserService.getByApple(appleEmail)) {
+export async function makeAppleCredential(appleEmail: string, appleSub: string, appleTransferSub?: string): Promise<UserCredential> {
+    if (await UserService.getByAppleEmail(appleEmail)) {
         throw new AlreadyRegisteredAppleEmailError(appleEmail);
     }
     return {
         appleEmail: appleEmail,
-        appleSub: appleSub
+        appleSub: appleSub,
+        appleTransferSub: appleTransferSub
     }
 }
 
-export async function transferAppleCredential(user: User, appleTransferSub: string): Promise<void> {
-    user.credential.appleSub = appleTransferSub;
+export async function transferAppleCredential(user: User, appleSub: string, appleEmail: string): Promise<void> {
+    user.credential.appleSub = appleSub;
+    user.credential.appleEmail = appleEmail;
     await modifyCredential(user);
 }
 

--- a/src/core/user/UserCredentialService.ts
+++ b/src/core/user/UserCredentialService.ts
@@ -142,6 +142,11 @@ export async function makeAppleCredential(appleEmail: string, appleSub: string):
     }
 }
 
+export async function transferAppleCredential(user: User, appleTransferSub: string): Promise<void> {
+    user.credential.appleSub = appleTransferSub;
+    await modifyCredential(user);
+}
+
 export async function makeFbCredential(fbId: string, fbToken: string): Promise<UserCredential> {
     if (await UserService.getByFb(fbId)) {
         throw new AlreadyRegisteredFbIdError(fbId);

--- a/src/core/user/UserRepository.ts
+++ b/src/core/user/UserRepository.ts
@@ -65,22 +65,22 @@ export async function findActiveByVerifiedEmail(email: string) : Promise<User> {
 }
 
 export async function findActiveByFb(fbId: string) : Promise<User> {
-  let mongooseDocument = await MongooseUserModel.findOne({'credential.fbId' : fbId, 'active' : true }).exec();
+  const mongooseDocument = await MongooseUserModel.findOne({'credential.fbId' : fbId, 'active' : true }).exec();
   return fromMongoose(mongooseDocument);
 }
 
 export async function findActiveByAppleEmail(appleEmail: string) : Promise<User> {
   const mongooseDocument = await MongooseUserModel.findOne({'credential.appleEmail' : appleEmail, 'active' : true}).exec();
-  return fromMongoose(mongooseDocument)
+  return fromMongoose(mongooseDocument);
 }
 
 export async function findActiveByAppleTransferSub(appleTransferSub: string) : Promise<User> {
   const mongooseDocument = await MongooseUserModel.findOne({'credential.appleTransferSub' : appleTransferSub, 'active' : true}).exec();
-  return fromMongoose(mongooseDocument)
+  return fromMongoose(mongooseDocument);
 }
 
 export async function findActiveByCredentialHash(hash: string): Promise<User> {
-  let mongooseDocument = await MongooseUserModel.findOne({'credentialHash' : hash, 'active' : true }).exec();
+  const mongooseDocument = await MongooseUserModel.findOne({'credentialHash' : hash, 'active' : true }).exec();
   return fromMongoose(mongooseDocument);
 }
 

--- a/src/core/user/UserRepository.ts
+++ b/src/core/user/UserRepository.ts
@@ -60,7 +60,7 @@ function fromMongoose(mongooseDocument: mongoose.MongooseDocument): User {
   }
 }
 export async function findActiveByVerifiedEmail(email: string) : Promise<User> {
-  let mongooseDocument = await MongooseUserModel.findOne({'email' : email, 'active' : true , 'isEmailVerified': true}).exec();
+  const mongooseDocument = await MongooseUserModel.findOne({'email' : email, 'active' : true , 'isEmailVerified': true}).exec();
   return fromMongoose(mongooseDocument);
 }
 

--- a/src/core/user/UserRepository.ts
+++ b/src/core/user/UserRepository.ts
@@ -13,6 +13,7 @@ let UserSchema = new mongoose.Schema({
     fbId: {type: String, default: null},
     appleEmail: {type: String, default: null},
     appleSub: {type: String, default: null},
+    appleTransferSub: {type: String, default: null},
 
     // 위 항목이 없어도 unique credentialHash을 생성할 수 있도록
     tempDate: {type: Date, default: null},          // 임시 가입 날짜
@@ -58,18 +59,23 @@ function fromMongoose(mongooseDocument: mongoose.MongooseDocument): User {
     lastLoginTimestamp: wrapper.lastLoginTimestamp
   }
 }
-export async function findActiveByVerifiedEmail(email:string) : Promise<User> {
+export async function findActiveByVerifiedEmail(email: string) : Promise<User> {
   let mongooseDocument = await MongooseUserModel.findOne({'email' : email, 'active' : true , 'isEmailVerified': true}).exec();
   return fromMongoose(mongooseDocument);
 }
 
-export async function findActiveByFb(fbId:string) : Promise<User> {
+export async function findActiveByFb(fbId: string) : Promise<User> {
   let mongooseDocument = await MongooseUserModel.findOne({'credential.fbId' : fbId, 'active' : true }).exec();
   return fromMongoose(mongooseDocument);
 }
 
-export async function findActiveByApple(appleEmail:string) : Promise<User> {
+export async function findActiveByAppleEmail(appleEmail: string) : Promise<User> {
   const mongooseDocument = await MongooseUserModel.findOne({'credential.appleEmail' : appleEmail, 'active' : true}).exec();
+  return fromMongoose(mongooseDocument)
+}
+
+export async function findActiveByAppleTransferSub(appleTransferSub: string) : Promise<User> {
+  const mongooseDocument = await MongooseUserModel.findOne({'credential.appleTransferSub' : appleTransferSub, 'active' : true}).exec();
   return fromMongoose(mongooseDocument)
 }
 

--- a/src/core/user/UserRepository.ts
+++ b/src/core/user/UserRepository.ts
@@ -69,8 +69,8 @@ export async function findActiveByFb(fbId: string) : Promise<User> {
   return fromMongoose(mongooseDocument);
 }
 
-export async function findActiveByAppleEmail(appleEmail: string) : Promise<User> {
-  const mongooseDocument = await MongooseUserModel.findOne({'credential.appleEmail' : appleEmail, 'active' : true}).exec();
+export async function findActiveByAppleSub(appleSub: string) : Promise<User> {
+  const mongooseDocument = await MongooseUserModel.findOne({'credential.appleSub' : appleSub, 'active' : true}).exec();
   return fromMongoose(mongooseDocument);
 }
 

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -13,7 +13,7 @@ import UserRepository = require('@app/core/user/UserRepository');
 import CourseBookService = require('@app/core/coursebook/CourseBookService');
 
 export function getVerifiedByEmail(email: string): Promise<User> {
-  return UserRepository.findActiveByVerifiedEmail(email)
+  return UserRepository.findActiveByVerifiedEmail(email);
 }
 
 export function getByMongooseId(mongooseId: string): Promise<User> {
@@ -25,7 +25,7 @@ export function getByLocalId(localId: string): Promise<User> {
 }
 
 export function getByFb(fbId: string): Promise<User> {
-  return UserRepository.findActiveByFb(fbId)
+  return UserRepository.findActiveByFb(fbId);
 }
 
 export function getByAppleEmail(appleEmail: string): Promise<User> {
@@ -33,7 +33,7 @@ export function getByAppleEmail(appleEmail: string): Promise<User> {
 }
 
 export function getByAppleTransferSub(appleTransferSub: string): Promise<User> {
-  return UserRepository.findActiveByAppleTransferSub(appleTransferSub)
+  return UserRepository.findActiveByAppleTransferSub(appleTransferSub);
 }
 
 export function getByCredentialHash(credentialHash: string): Promise<User> {

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -28,8 +28,8 @@ export function getByFb(fbId: string): Promise<User> {
   return UserRepository.findActiveByFb(fbId);
 }
 
-export function getByAppleEmail(appleEmail: string): Promise<User> {
-  return UserRepository.findActiveByAppleEmail(appleEmail);
+export function getByAppleSub(appleSub: string): Promise<User> {
+  return UserRepository.findActiveByAppleSub(appleSub);
 }
 
 export function getByAppleTransferSub(appleTransferSub: string): Promise<User> {

--- a/src/core/user/UserService.ts
+++ b/src/core/user/UserService.ts
@@ -28,8 +28,12 @@ export function getByFb(fbId: string): Promise<User> {
   return UserRepository.findActiveByFb(fbId)
 }
 
-export function getByApple(appleEmail: string): Promise<User> {
-  return UserRepository.findActiveByApple(appleEmail);
+export function getByAppleEmail(appleEmail: string): Promise<User> {
+  return UserRepository.findActiveByAppleEmail(appleEmail);
+}
+
+export function getByAppleTransferSub(appleTransferSub: string): Promise<User> {
+  return UserRepository.findActiveByAppleTransferSub(appleTransferSub)
 }
 
 export function getByCredentialHash(credentialHash: string): Promise<User> {

--- a/src/core/user/error/AlreadyRegisteredAppleEmailError.ts
+++ b/src/core/user/error/AlreadyRegisteredAppleEmailError.ts
@@ -1,5 +1,0 @@
-export default class AlreadyRegisteredAppleEmailError extends Error {
-    constructor(public appleEmail: string) {
-        super("Already registered apple email '" + appleEmail + "'");
-    }
-}

--- a/src/core/user/error/AlreadyRegisteredAppleSubError.ts
+++ b/src/core/user/error/AlreadyRegisteredAppleSubError.ts
@@ -1,0 +1,5 @@
+export default class AlreadyRegisteredAppleSubError extends Error {
+    constructor(public appleSub: string) {
+        super("Already registered apple sub '" + appleSub + "'");
+    }
+}

--- a/src/core/user/model/UserCredential.ts
+++ b/src/core/user/model/UserCredential.ts
@@ -5,6 +5,7 @@ export default interface UserCredential {
   fbId?: string;
   appleEmail?: string;
   appleSub?: string;
+  appleTransferSub?: string;
   tempDate?: Date;
   tempSeed?: number;
 };


### PR DESCRIPTION
관련 문서:
- https://developer.apple.com/documentation/sign_in_with_apple/transferring_your_apps_and_users_to_another_team
- https://developer.apple.com/documentation/sign_in_with_apple/bringing_new_apps_and_users_into_your_team

관련 슬랙:
- https://wafflestudio.slack.com/archives/C0PAVPS5T/p1666956238651019

**중요한 변경이라 실수가 없는지 찬찬히 봐주세요.**

iOS 에서 App Transfer 절차를 시작하고 이후에 유저에 의해 `/login_apple` 동작 시,
- apple token 을 애플에 보내면, 기존에 가입한 유저의 경우 `transfer_sub` 이 옴 (안 오면 그냥 하던대로 sub 만 이용해서 신규 가입 처리하면 됨)
- `transfer_sub` 이 온 경우, [snutt-ios-transfer-scripts](https://github.com/wafflestudio/snutt-ios-transfer-scripts)를 통해 기존 애플 로그인 유저 DB 에 넣어둔 `credential.appleTransferSub` 과 비교
- 두 개가 같으면 기존 유저 DB 의 `credential.appleSub`을 `transfer_sub`으로 업데이트
- 유저의 credential 이 바뀌었으므로, credentialHash 도 재생성
