### PR TITLE
timetable의 lecture id를 기존 lectureid와 통일

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/src/core/timetable/TimetableLectureService.ts
+++ b/src/core/timetable/TimetableLectureService.ts
@@ -35,12 +35,13 @@ export async function addRefLecture(timetable: Timetable, lectureId: string, isF
   }
   let colorIndex = getAvailableColorIndex(timetable);
   let userLecture = fromRefLecture(lecture, colorIndex);
+
+  ObjectUtil.deleteObjectId(userLecture);
+  userLecture._id = lectureId;
   await addLecture(timetable, userLecture, isForced);
 }
 
 export async function addLecture(timetable: Timetable, lecture: UserLecture, isForced: boolean = false): Promise<void> {
-  ObjectUtil.deleteObjectId(lecture);
-
   if (lecture.credit && (typeof lecture.credit === 'string' || <any>lecture.credit instanceof String)) {
     lecture.credit = Number(lecture.credit);
   }
@@ -76,6 +77,7 @@ export async function addLecture(timetable: Timetable, lecture: UserLecture, isF
 
 export async function addCustomLecture(timetable: Timetable, lecture: UserLecture, isForced: boolean): Promise<void> {
   if (isInvalidClassTime(lecture)) throw new InvalidLectureTimeJsonError()
+  ObjectUtil.deleteObjectId(lecture);
   syncRealTimeWithPeriod(lecture)
 
   /* If no time json is found, mask is invalid */
@@ -279,6 +281,7 @@ function isIdenticalCourseLecture(l1: UserLecture, l2: UserLecture): boolean {
 function fromRefLecture(refLecture: RefLecture, colorIndex: number): UserLecture {
   let creationDate = new Date();
   return {
+    _id: refLecture._id,
     classification: refLecture.classification,                           // 교과 구분
     department: refLecture.department,                               // 학부
     academic_year: refLecture.academic_year,                            // 학년

--- a/src/core/timetable/TimetableLectureService.ts
+++ b/src/core/timetable/TimetableLectureService.ts
@@ -23,6 +23,7 @@ import InvalidLectureTimeJsonError from '../lecture/error/InvalidLectureTimeJson
 import winston = require('winston');
 import {Time} from "@app/core/timetable/model/Time";
 import Lecture from "@app/core/lecture/model/Lecture";
+import * as mongoose from "mongoose";
 let logger = winston.loggers.get('default');
 
 const ZERO_PERIOD_START_HOUR = 8
@@ -77,7 +78,6 @@ export async function addLecture(timetable: Timetable, lecture: UserLecture, isF
 
 export async function addCustomLecture(timetable: Timetable, lecture: UserLecture, isForced: boolean): Promise<void> {
   if (isInvalidClassTime(lecture)) throw new InvalidLectureTimeJsonError()
-  ObjectUtil.deleteObjectId(lecture);
   syncRealTimeWithPeriod(lecture)
 
   /* If no time json is found, mask is invalid */
@@ -90,6 +90,8 @@ export async function addCustomLecture(timetable: Timetable, lecture: UserLectur
     lecture.colorIndex = getAvailableColorIndex(timetable);
   }
 
+  ObjectUtil.deleteObjectId(lecture);
+  lecture._id = mongoose.Types.ObjectId().toHexString();
   await addLecture(timetable, lecture, isForced);
 }
 

--- a/src/core/timetable/TimetableRepository.ts
+++ b/src/core/timetable/TimetableRepository.ts
@@ -12,6 +12,7 @@ import SnuttevLectureKey from "@app/core/lecture/model/SnuttevLectureKey";
 export const NUMBER_OF_THEME = 6
 
 let userLectureSchema = new mongoose.Schema({
+  _id: mongoose.Schema.Types.ObjectId,
   classification: String,                           // 교과 구분
   department: String,                               // 학부
   academic_year: String,                            // 학년
@@ -245,7 +246,6 @@ export async function insert(table: Timetable): Promise<Timetable> {
 }
 
 export async function insertUserLecture(tableId: string, lecture: UserLecture): Promise<void> {
-  ObjectUtil.deleteObjectId(lecture);
   let document = await mongooseModel.findOne({'_id': tableId}).exec();
   document['lecture_list'].push(lecture);
   await document.save();

--- a/src/core/timetable/TimetableRepository.ts
+++ b/src/core/timetable/TimetableRepository.ts
@@ -8,6 +8,8 @@ import UserLectureNotFoundError from './error/UserLectureNotFoundError';
 import ObjectUtil = require('@app/core/common/util/ObjectUtil');
 import CourseBook from "@app/core/coursebook/model/CourseBook";
 import SnuttevLectureKey from "@app/core/lecture/model/SnuttevLectureKey";
+import {Types} from "mongoose";
+import {ObjectId} from "mongodb";
 
 export const NUMBER_OF_THEME = 6
 

--- a/test/integration/timetable_test.ts
+++ b/test/integration/timetable_test.ts
@@ -344,10 +344,6 @@ export = function(request: supertest.SuperTest<supertest.Test>) {
         "category": "",
         "created_at": "2016-03-31T07:56:44.137Z",
         "updated_at": "2016-03-31T07:56:44.137Z",
-        /*
-         * See to it that the server removes _id fields correctly
-         */
-        "_id": "56fcd83c041742971bd20a86",
         "colorIndex": 5,
         "class_time_mask": [
           0,
@@ -404,9 +400,6 @@ export = function(request: supertest.SuperTest<supertest.Test>) {
         "category": "",
         "created_at": "2016-03-31T07:56:44.137Z",
         "updated_at": "2016-03-31T07:56:44.137Z",
-        /*
-         * See to it that the server removes _id fields correctly
-         */
         "_id": "56fcd83c041742971bd20a86",
         "class_time_json": [
           {
@@ -447,9 +440,6 @@ export = function(request: supertest.SuperTest<supertest.Test>) {
         "category": "",
         "created_at": "2016-03-31T07:56:44.137Z",
         "updated_at": "2016-03-31T07:56:44.137Z",
-        /*
-         * See to it that the server removes _id fields correctly
-         */
         "_id": "56fcd83c041742971bd20a86",
         "class_time_json": [
           {
@@ -494,9 +484,6 @@ export = function(request: supertest.SuperTest<supertest.Test>) {
           "fg": "rgb(255, 255, 255)",
           "bg": "#555555"
         },
-        /*
-         * See to it that the server removes _id fields correctly
-         */
         "_id": "56fcd83c041742971bd20a86",
         "class_time_json": [
           {
@@ -542,9 +529,6 @@ export = function(request: supertest.SuperTest<supertest.Test>) {
         "category": "",
         "created_at": "2016-03-31T07:56:44.137Z",
         "updated_at": "2016-03-31T07:56:44.137Z",
-        /*
-         * See to it that the server removes _id fields correctly
-         */
         "_id": "56fcd83c041742971bd20a86",
         "class_time_json": [
           {
@@ -681,9 +665,6 @@ export = function(request: supertest.SuperTest<supertest.Test>) {
         "category": "",
         "created_at": "2016-03-31T07:56:44.137Z",
         "updated_at": "2016-03-31T07:56:44.137Z",
-        /*
-         * See to it that the server removes _id fields correctly
-         */
         "_id": "56fcd83c041742971bd20a86",
         "class_time_json": [
           {


### PR DESCRIPTION
- timetable의 lecture id를 실제 lectuer id와 동일하게 쌓도록 변경
- lecture id 삭제하는 로직이 있어서 다시 lectureId 넣어주도록 설정 ( custom 강의는 그냥 id 비우도록 설정 )


ci 는 18.04 deprecated 되어서 바꿨슴다. 
참고: https://github.com/actions/runner-images/issues/6002 